### PR TITLE
Add cmake project

### DIFF
--- a/vol1/c-examples/CMakeLists.txt
+++ b/vol1/c-examples/CMakeLists.txt
@@ -1,0 +1,24 @@
+include_directories(.)
+
+add_executable(aifh_vol1 AIFH-VOL1.c
+    Data.c
+    Distance.c
+    Equilateral.c
+    ExampleAnalyze.c
+    ExampleDistance.c
+    ExampleKMeans.c
+    ExampleNormalize.c
+    ExamplePI.c
+    ExampleRandom.c
+    ExampleReadCSV.c
+    ExampleSimpleNormalize.c
+    ExampleTest.c
+    ExampleUtil.c
+    KMeans.c
+    Normalize.c
+    Random.c
+    libcsv.c
+    mt19937ar.c)
+
+# Needs maths
+target_link_libraries(aifh_vol1 m)


### PR DESCRIPTION
Should replace makefiles, VS projects and Xcode projects.

Standard cmake configuration is as per:
- mkdir _build_; cd _build_
- cmake ..
- open generated project or run make or ninja in _build_ directory

Source directory always stays clean.
