### PR TITLE
Fixed trapping NonLocalReturnControl

### DIFF
--- a/vol2/vol2-scala-examples/src/main/scala/com/heatonresearch/aifh/evolutionary/train/basic/EAWorker.scala
+++ b/vol2/vol2-scala-examples/src/main/scala/com/heatonresearch/aifh/evolutionary/train/basic/EAWorker.scala
@@ -34,6 +34,7 @@ import com.heatonresearch.aifh.evolutionary.opp.EvolutionaryOperator
 import com.heatonresearch.aifh.evolutionary.species.Species
 import com.heatonresearch.aifh.randomize.GenerateRandom
 import java.util.concurrent.Callable
+import scala.util.control.ControlThrowable
 
 /**
  * A worker thread for an Evolutionary Algorithm.
@@ -106,6 +107,7 @@ class EAWorker(train: BasicEA, species: Species) extends Callable[AnyRef] {
           if (tries < 0) {
             throw new AIFHError(s"Could not perform a successful genetic operation after ${train.maxOperationErrors} tries.")
           }
+        case t: ControlThrowable => throw t
         case t: Throwable =>
           if (!train.shouldIgnoreExceptions) {
             train.reportError(t)


### PR DESCRIPTION
Hi Jeff, thanks for your excellent book and code! But I failed to run the Scala version of FindEquation.

It seems the problem came from https://github.com/jeffheaton/aifh/blob/a22f68f160e3ce5522da6e23afae99c115911c3d/vol2/vol2-scala-examples/src/main/scala/com/heatonresearch/aifh/evolutionary/train/basic/EAWorker.scala#L109-L112
where the control flow related exception `scala.runtime.NonLocalReturnControl` got trapped in the catch-all `case t: Throwable`. This patch should fix the issue.