### PR TITLE
Fixes

### DIFF
--- a/vol1/java-examples/src/main/java/com/heatonresearch/aifh/examples/normalize/NormalizeCSVExample.java
+++ b/vol1/java-examples/src/main/java/com/heatonresearch/aifh/examples/normalize/NormalizeCSVExample.java
@@ -60,11 +60,11 @@ public class NormalizeCSVExample {
 
             // The following ranges are setup for the Iris data set.  If you wish to normalize other files you will
             // need to modify the below function calls other files.
-            ds.normalizeRange(0, 0, 1);
-            ds.normalizeRange(1, 0, 1);
-            ds.normalizeRange(2, 0, 1);
-            ds.normalizeRange(3, 0, 1);
-            ds.encodeEquilateral(4);
+            ds.normalizeRange(0, -1, 1);
+            ds.normalizeRange(1, -1, 1);
+            ds.normalizeRange(2, -1, 1);
+            ds.normalizeRange(3, -1, 1);
+            ds.encodeEquilateral(4,-1,1);
             final File outputFile = new File("normalized.csv");
             DataSet.save(outputFile, ds);
             System.out.println("Output written to: " + outputFile.getAbsolutePath());

--- a/vol1/java-examples/src/main/java/com/heatonresearch/aifh/normalize/DataSet.java
+++ b/vol1/java-examples/src/main/java/com/heatonresearch/aifh/normalize/DataSet.java
@@ -442,7 +442,8 @@ public class DataSet {
         // make space for it
         final Map<String, Integer> classes = enumerateClasses(column);
         final int classCount = classes.size();
-        insertColumns(column + 1, classCount - 1);
+        // we'll use classCount - 1 columns, and we have the original column to reuse
+        insertColumns(column + 1, classCount - 2);
 
         // perform the equilateral
         final Equilateral eq = new Equilateral(classCount, offValue, onValue);
@@ -458,7 +459,7 @@ public class DataSet {
         }
 
         // name the new columns
-        for (int i = 0; i < classes.size(); i++) {
+        for (int i = 0; i < classCount - 1; i++) {
             this.headers[column + i] = name + "-" + i;
         }
 

--- a/vol1/java-examples/src/test/java/com/heatonresearch/aifh/normalize/TestDataSet.java
+++ b/vol1/java-examples/src/test/java/com/heatonresearch/aifh/normalize/TestDataSet.java
@@ -34,7 +34,12 @@ import com.heatonresearch.aifh.general.data.BasicData;
 import org.junit.Test;
 
 import java.io.File;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -186,7 +191,29 @@ public class TestDataSet {
     @Test
     public void testEncodeEquilateral() {
         final DataSet ds1 = generateTestData();
-        ds1.encodeEquilateral(0);
+        ds1.encodeEquilateral(0,-1,1);
+        // 3 headers, first one replaced by 2 columns to store 3 values in equilateral encoding
+        assertEquals(4,ds1.getHeaderCount());
+        Set<Double> col1=new HashSet<>();
+        Set<Double> col2=new HashSet<>();
+        for (Object[] row:ds1.getData()){
+            col1.add(round((Double)row[0]));
+            col2.add(round((Double)row[1]));
+        }
+        Set<Double> expected1=new HashSet<>(Arrays.<Double>asList(0.0,-0.866,0.866));
+        Set<Double> expected2=new HashSet<>(Arrays.<Double>asList(1.0,-0.5));
+        assertEquals(expected1,col1);
+        assertEquals(expected2,col2);
+
+    }
+
+    /**
+     * round a double to 3 decimal places for comparisons in tests
+     * @param value the value to round
+     * @return the rounded value
+     */
+    public static double round(double value) {
+        return new BigDecimal(value).setScale(3, RoundingMode.HALF_UP).doubleValue();
     }
 
     @Test

--- a/vol1/python-examples/examples/example_normalize.py
+++ b/vol1/python-examples/examples/example_normalize.py
@@ -212,7 +212,7 @@ for i in range(0, 4):
 # Discover all of the classes for column #4, the iris species.
 classes = norm.build_class_map(result, 4)
 
-# Normalize iris species as one-of-n
+# Normalize iris species with equilateral encoding
 norm.norm_col_equilateral(result, 4, classes, -1, 1)
 
 # Display the resulting data


### PR DESCRIPTION
While working on the first examples I found an incorrect comment in the python code, and the Java code add one column too many for equilateral encoding.