### PR TITLE
fix spelling error (compure -> compute)

### DIFF
--- a/vol1/python-examples/lib/aifh/rbf_network.py
+++ b/vol1/python-examples/lib/aifh/rbf_network.py
@@ -109,7 +109,7 @@ class RbfNetwork(object):
         for i in xrange(0, len(self.long_term_memory)):
             self.long_term_memory[i] = np.random.uniform(0, 1)
 
-    def compure_classification(self, input):
+    def compute_classification(self, input):
         """ Compute the output and return the index of the output with the largest value.  This is the class that
         the network recognized.
         @param input: The input pattern.

--- a/vol1/python-examples/test/aifh/test_rbf_network.py
+++ b/vol1/python-examples/test/aifh/test_rbf_network.py
@@ -116,7 +116,7 @@ class TestRbfNetwork(unittest.TestCase):
         # Outputs: (1*5) + (1*6) = 11
         self.assertAlmostEqual(11, y[1], 3)
 
-        cls = network.compure_classification(x)
+        cls = network.compute_classification(x)
 
         # class 1 is higher than class 0
         self.assertEqual(1, cls)

--- a/vol2/vol2-python-examples/lib/aifh/rbf_network.py
+++ b/vol2/vol2-python-examples/lib/aifh/rbf_network.py
@@ -109,7 +109,7 @@ class RbfNetwork(object):
         for i in range(0, len(self.long_term_memory)):
             self.long_term_memory[i] = np.random.uniform(0, 1)
 
-    def compure_classification(self, input):
+    def compute_classification(self, input):
         """ Compute the output and return the index of the output with the largest value.  This is the class that
         the network recognized.
         @param input: The input pattern.

--- a/vol3/vol3-python-examples/lib/aifh/rbf_network.py
+++ b/vol3/vol3-python-examples/lib/aifh/rbf_network.py
@@ -102,7 +102,7 @@ class RbfNetwork(object):
         for i in range(0, len(self.long_term_memory)):
             self.long_term_memory[i] = np.random.uniform(0, 1)
 
-    def compure_classification(self, input):
+    def compute_classification(self, input):
         """ Compute the output and return the index of the output with the largest value.  This is the class that
         the network recognized.
         @param input: The input pattern.


### PR DESCRIPTION
Noticed this small one while reading through the code examples.